### PR TITLE
Allow configurable md4c include path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Current tables limitations:
 ## Usage
 
 Add imgui_md.h imgui_md.cpp md4c.h md4c.c to your project and use the following code:
+If md4c.h is located elsewhere, you can override its path by defining `IMGUI_MD_MD4C_INCLUDE`, for example:
+
+```
+g++ -DIMGUI_MD_MD4C_INCLUDE=\"path/to/md4c.h\"
+```
 
 ```cpp
 #include "imgui_md.h"

--- a/imgui_md.h
+++ b/imgui_md.h
@@ -26,7 +26,12 @@
 #ifndef IMGUI_MD_H
 #define IMGUI_MD_H
 
-#include "md4c.h"
+#ifndef IMGUI_MD_MD4C_INCLUDE
+#  define IMGUI_MD_MD4C_INCLUDE "md4c.h"
+#endif
+extern "C" {
+#  include IMGUI_MD_MD4C_INCLUDE
+}
 #include "imgui.h"
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Summary
- Allow overriding md4c header via IMGUI_MD_MD4C_INCLUDE macro and wrap include in `extern "C"`
- Document how to override md4c header path in the README

## Testing
- `g++ -std=c++11 -c imgui_md.cpp 2>&1 | head -n 20` *(fails: md4c.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b77b6ddee4832caa162e956cf9596b