### PR TITLE
Add node editor compile guard and document flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If md4c.h is located elsewhere, you can override its path by defining `IMGUI_MD_
 g++ -DIMGUI_MD_MD4C_INCLUDE=\"path/to/md4c.h\"
 ```
 
+If you use ImGui's node editor, enable its integration by defining `IMGUI_MD_WITH_NODE_EDITOR=1` during compilation. The flag defaults to `0`, which provides a stub and avoids link errors when the node editor is not present.
+
 ```cpp
 #include "imgui_md.h"
 

--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -149,8 +149,15 @@ void imgui_md::BLOCK_QUOTE(bool)
 
 }
 
+#ifndef IMGUI_MD_WITH_NODE_EDITOR
+#  define IMGUI_MD_WITH_NODE_EDITOR 0
+#endif
 
-bool Priv_ImGuiNodeEditor_IsInCanvas();  // Forward declaration (hidden API of imgui.cpp, specific to ImGui Bundle)
+#if IMGUI_MD_WITH_NODE_EDITOR
+extern bool Priv_ImGuiNodeEditor_IsInCanvas();  // Forward declaration (hidden API of imgui.cpp, specific to ImGui Bundle)
+#else
+static inline bool Priv_ImGuiNodeEditor_IsInCanvas() { return false; }
+#endif
 
 void imgui_md::BLOCK_CODE(const MD_BLOCK_CODE_DETAIL* detail, bool e)
 {


### PR DESCRIPTION
## Summary
- add `IMGUI_MD_WITH_NODE_EDITOR` guard with stub `Priv_ImGuiNodeEditor_IsInCanvas`
- document the `IMGUI_MD_WITH_NODE_EDITOR` build flag in the README

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68b77c949eac832c882127fc427d4e05