### PR TITLE
fix(build): resolve duplicate print definition

### DIFF
--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -774,7 +774,7 @@ int imgui_md::block(int type, void* d, bool e)
         case MD_BLOCK_H:
         {
                 auto* in = (MD_BLOCK_H_DETAIL*)d;
-                MdBlockHDetail out{ in->level };
+                MdBlockHDetail out{ static_cast<int>(in->level) };
                 BLOCK_H(&out, e);
         }
                 break;
@@ -868,10 +868,8 @@ int imgui_md::span(int type, void* d, bool e)
 }
 
 int imgui_md::print(const char* str, const char* str_end)
-
-int imgui_md::print(const char* str, const char* str_end)
 {
-	if (str >= str_end)
+        if (str >= str_end)
         return 0;
 
     // Markdown rendering always start with a call to ImGui::NewLine()


### PR DESCRIPTION
## Summary
- remove redundant forward declaration of `imgui_md::print`
- cast heading level to `int` to avoid narrowing warning

## Testing
- `g++ -std=c++17 -c imgui_md.cpp` *(fails: imgui.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b790ac66e0832c819f82b9c2096281